### PR TITLE
Upgrade atlas to java 21

### DIFF
--- a/Dockerfile.atlas
+++ b/Dockerfile.atlas
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy as base
 RUN apt-get update && \
-    apt-get install --yes openjdk-17-jre-headless && \
+    apt-get install --yes openjdk-21-jre-headless && \
     apt-get clean
 
 FROM base as builder


### PR DESCRIPTION
Atlas code requires java 21 now